### PR TITLE
Fix all logs getting omitted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ This project tries to use [SemVer 2.0.0](https://semver.org)
 
 - Added debug logging, enabled by specifying `-vv` or `--verbose=2`. (#13)
 
+- Fixed default maximum severity being set to "Unknown", i.e. the lowest severity
+  level, causing all logs except the unknown ones to be omitted. This was caused
+  by the value "none" being invalidly interpreted as "Unknown", and is now
+  correctly interpreted as "Undefined". (#14)
+
 ## v0.2.0 (2021-02-09)
 
 - Added list of severities in the help text. (#12)

--- a/kong.go
+++ b/kong.go
@@ -16,7 +16,8 @@ func flogHelp(options kong.HelpOptions, ctx *kong.Context) error {
 
 	fmt.Println(`
 Severities:
-  Unknown        1, none, null, ?, u, ukwn, unknown
+  Undefined      0, n, nil, null, none, unde, undefined
+  Unknown        1, ?, u, ukwn, unkn, unknown
   Trace          2, t, tra, trac, trce, trace
   Debug          3, d, deb, debu, debg, dbug, debug
   Information    4, i, inf, info, information
@@ -67,7 +68,10 @@ func (m levelMapper) Decode(ctx *kong.DecodeContext, target reflect.Value) error
 
 func parseLevelString(s string) (loglevel.Level, error) {
 	switch strings.ToLower(s) {
-	case "1", "none", "null", "u", "?", "ukwn", "unknown":
+	case "0", "nil", "null", "none", "unde", "undefined":
+		return loglevel.Undefined, nil
+
+	case "1", "u", "?", "ukwn", "unkn", "unknown":
 		return loglevel.Unknown, nil
 
 	case "2", "t", "tra", "trac", "trce", "trace":


### PR DESCRIPTION
The default for `-S` was set to `none`. A regression from #12 changed the
meaning of `none` and so it was interpreted as the "loglevel.Unknown" logging
level, which actually is the lowest used logging level.

This works now by changing `none` to be interpreted as "loglevel.Undefined"
